### PR TITLE
[BREAKING CHANGE] Remove use of `cross-blob`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "license": "MIT",
       "dependencies": {
         "base64-arraybuffer": "^1.0.2",
-        "cross-blob": "^3.0.2",
         "p-limit": "^6.0.0",
         "uuid": "^11.0.1"
       },
@@ -176,11 +175,6 @@
         "node": ">= 0.6.0"
       }
     },
-    "node_modules/blob-polyfill": {
-      "version": "7.0.20220408",
-      "resolved": "https://registry.npmjs.org/blob-polyfill/-/blob-polyfill-7.0.20220408.tgz",
-      "integrity": "sha512-oD8Ydw+5lNoqq+en24iuPt1QixdPpe/nUF8azTHnviCZYu9zUC+TwdzIp5orpblJosNlgNbVmmAb//c6d6ImUQ=="
-    },
     "node_modules/brace-expansion": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
@@ -207,18 +201,6 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
-    },
-    "node_modules/cross-blob": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/cross-blob/-/cross-blob-3.0.2.tgz",
-      "integrity": "sha512-u+7xq68MAjIqvoEKrdgIEupKJNBeU8MSl/cpfPmJ3rm9yvxrgbMPr8TkZS9qnwCgiVC8BsEt9kDkeD7He2zmNA==",
-      "dependencies": {
-        "blob-polyfill": "^7.0.20220408",
-        "fetch-blob": "^3.2.0"
-      },
-      "engines": {
-        "node": "^12.20 || >=14.13"
-      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
@@ -256,28 +238,6 @@
       },
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
-      }
-    },
-    "node_modules/fetch-blob": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
-      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/jimmywarting"
-        },
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/jimmywarting"
-        }
-      ],
-      "dependencies": {
-        "node-domexception": "^1.0.0",
-        "web-streams-polyfill": "^3.0.3"
-      },
-      "engines": {
-        "node": "^12.20 || >= 14.13"
       }
     },
     "node_modules/foreground-child": {
@@ -447,24 +407,6 @@
       "dev": true,
       "engines": {
         "node": ">=16 || 14 >=14.17"
-      }
-    },
-    "node_modules/node-domexception": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
-      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/jimmywarting"
-        },
-        {
-          "type": "github",
-          "url": "https://paypal.me/jimmywarting"
-        }
-      ],
-      "engines": {
-        "node": ">=10.5.0"
       }
     },
     "node_modules/p-limit": {
@@ -723,14 +665,6 @@
       "license": "MIT",
       "bin": {
         "uuid": "dist/esm/bin/uuid"
-      }
-    },
-    "node_modules/web-streams-polyfill": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz",
-      "integrity": "sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==",
-      "engines": {
-        "node": ">= 8"
       }
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
   },
   "dependencies": {
     "base64-arraybuffer": "^1.0.2",
-    "cross-blob": "^3.0.2",
     "p-limit": "^6.0.0",
     "uuid": "^11.0.1"
   },

--- a/spec/lib/TransferFilePoolSpec.js
+++ b/spec/lib/TransferFilePoolSpec.js
@@ -1,4 +1,3 @@
-import Blob from "cross-blob";
 import { TransferFilePool } from "../../lib/index.js";
 
 describe("testing the TransferFilePool class", () => {

--- a/src/TransferFile.ts
+++ b/src/TransferFile.ts
@@ -1,4 +1,3 @@
-import Blob from "cross-blob";
 import pLimit from "p-limit";
 import {
   AskFilePartCallback,

--- a/src/TransferFilePool.ts
+++ b/src/TransferFilePool.ts
@@ -1,4 +1,3 @@
-import Blob from "cross-blob";
 import { v4 as uuidv4 } from "uuid";
 import { TransferFile, TransferFileBlob } from "./TransferFile.js";
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,3 @@
-export { default as Blob } from "cross-blob";
 export {
   TransferFile,
   TransferFileBlob,


### PR DESCRIPTION
This removes the use of `cross-blob`, as `Blob` is now part of NodeJS (starting Node 18) and is supported by the modern browsers: https://developer.mozilla.org/en-US/docs/Web/API/Blob#browser_compatibility

This is a breaking change, as this will require at least Node >= 18 and `Blob` will not be exported anymore by the library.