### PR TITLE
Build documentation by calling `npx` and by loading the mermaid plugin

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -22,7 +22,7 @@ jobs:
         run: npm install
 
       - name: Generate documentation
-        run: ./node_modules/typedoc/bin/typedoc src/index.ts --out docs --cname lib-filetransfer.ludovicm67.fr
+        run: npx typedoc src/index.ts --out docs --plugin typedoc-plugin-mermaid --cname lib-filetransfer.ludovicm67.fr
 
       - name: Deploy to GitHub Pages
         uses: JamesIves/github-pages-deploy-action@v4.7.3


### PR DESCRIPTION
This fixes the documentation build that was failing previously.